### PR TITLE
feat: dynamically get version from package metadata

### DIFF
--- a/yolox/__init__.py
+++ b/yolox/__init__.py
@@ -1,1 +1,2 @@
-__version__ = "0.4.0"
+from importlib.metadata import version
+__version__ = version("pixeltable-yolox")


### PR DESCRIPTION
The pixeltable-yolox\yolox\__init__.py contains a hardcoded version. This is problematic as its already out of date with the current release. Instead of remembering to hard code it. We will use a dynamic method to match pyproject.toml